### PR TITLE
fix: .app 默认配置路径与自动生成 config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ python -m mirroring_keymap.ui_main
 open dist/MirroringKeymap.app
 ```
 
+首次启动 UI 时，会在 `~/Library/Application Support/MirroringKeymap/config.json` 自动生成一份默认配置（点位为占位值），你可以在 UI 里点“打开”直接编辑。
+
 ## 坐标说明
 
 当前实现使用 Quartz 全局坐标系（与 `CGEventGetLocation`/`CGWarpMouseCursorPosition` 一致，通常 **原点在主屏左下角**，单位为 points）。建议用 `mirroring-keymap pick` 取点，避免手工换算。

--- a/mirroring_keymap/default_config.py
+++ b/mirroring_keymap/default_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+# 注意：该默认配置用于“首次启动 UI 时自动生成”，避免 .app 内默认路径找不到 config.json 导致启动失败。
+# 用户应通过 UI 的“打开”按钮编辑该文件，填入实际点位坐标。
+
+DEFAULT_CONFIG_JSON = """\
+{
+  "version": 1,
+  "targetWindow": {
+    "titleHint": "iPhone Mirroring",
+    "pid": null,
+    "windowId": null
+  },
+  "global": {
+    "enableHotkey": "F8",
+    "panicHotkey": "F12",
+    "cameraLockKey": "CapsLock",
+    "backpackKey": "Tab",
+    "rrandDefaultPx": 0
+  },
+  "profiles": [
+    {
+      "name": "Default",
+      "points": {
+        "C": [200, 200],
+        "A": [800, 400],
+        "F": [950, 260],
+        "S": [1010, 260],
+        "I": [980, 680]
+      },
+      "joystick": { "radiusPx": 120, "tauMs": 60, "rrandPx": null },
+      "camera": {
+        "tcamPx": 3,
+        "radiusPx": 80,
+        "invertY": false,
+        "sensitivity": 1.0,
+        "rrandPx": null
+      },
+      "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },
+      "scope": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },
+      "wheel": { "enabled": true, "dPx": 8, "stopMs": 120, "invert": false, "rrandPx": null },
+      "scheduler": {
+        "tickHz": 120,
+        "cameraMinHz": 50,
+        "joystickMinHz": 20,
+        "cameraBudgetMs": 6,
+        "maxStepPx": 6
+      }
+    }
+  ],
+  "customMappings": [
+    { "name": "Use", "key": "E", "type": "tap", "point": [820, 300], "tapHoldMs": 30, "rrandPx": 2 }
+  ]
+}
+"""
+

--- a/mirroring_keymap/ui_app.py
+++ b/mirroring_keymap/ui_app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 from .config import AppConfig, ProfileConfig, load_config, select_profile
+from .default_config import DEFAULT_CONFIG_JSON
 
 
 def _is_macos() -> bool:
@@ -57,6 +58,16 @@ class UIApp:
         cfg = load_config(path)
         profile_names = [p.name for p in cfg.profiles]
         return cfg, profile_names
+
+    def default_config_path(self) -> str:
+        base = Path.home() / "Library" / "Application Support" / "MirroringKeymap"
+        return str(base / "config.json")
+
+    def ensure_default_config_exists(self, path: str) -> None:
+        p = Path(path).expanduser()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if not p.exists():
+            p.write_text(DEFAULT_CONFIG_JSON, encoding="utf-8")
 
     def start(self, cfg_path: str, profile_name: Optional[str]) -> None:
         if self._runtime is not None:

--- a/mirroring_keymap/ui_cocoa.py
+++ b/mirroring_keymap/ui_cocoa.py
@@ -70,6 +70,11 @@ class AppDelegate(NSObject):
 
         self._create_menu()
         self._create_window()
+        # 首次启动时自动创建默认配置到用户目录，避免 .app Resources 下找不到 config.json
+        try:
+            self._app.ensure_default_config_exists(self._cfg_path())
+        except Exception as e:
+            self._log.debug("ensure default config failed: %s", e)
         self._refresh_profiles_from_current_path()
 
         self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
@@ -116,7 +121,7 @@ class AppDelegate(NSObject):
 
         # 配置路径
         self._cfg_path_field = NSTextField.alloc().initWithFrame_(NSMakeRect(20, 310, 420, 24))
-        self._cfg_path_field.setStringValue_(str(Path("config.json").resolve()))
+        self._cfg_path_field.setStringValue_(self._app.default_config_path())
         content.addSubview_(self._cfg_path_field)
 
         btn_choose = NSButton.alloc().initWithFrame_(NSMakeRect(450, 308, 80, 28))


### PR DESCRIPTION
修复 .app 首次启动默认配置路径指向包内 Resources，导致点击“启动服务”时报错：

`[Errno 2] No such file or directory: .../Contents/Resources/config.json`

改动：
- UI 默认配置路径改为 `~/Library/Application Support/MirroringKeymap/config.json`
- 首次启动 UI 自动生成默认配置文件（占位点位，用户可在 UI 点“打开”编辑）

