### PR TITLE
增加日志/点位标记覆盖层 + 目标窗口配置，便于定位无反应问题

### DIFF
--- a/mirroring_keymap/macos/window.py
+++ b/mirroring_keymap/macos/window.py
@@ -27,18 +27,22 @@ def is_target_frontmost(cfg: TargetWindowConfig) -> bool:
     MVP 策略：
     - 如果配置了 pid：要求前台 pid 匹配
     - 否则：前台应用存在且其窗口列表中存在包含 titleHint 的窗口名
+    - 兼容：若 pid 不匹配但 titleHint 仍能匹配，则视为命中（便于 iPhone Mirroring 重启后 pid 变化）
     """
     require_macos()
     front = get_frontmost()
 
-    if cfg.pid is not None:
-        return front.pid == cfg.pid
-
     title_hint = (cfg.titleHint or "").strip().lower()
-    if not title_hint:
-        return False
+    if cfg.pid is not None and front.pid == cfg.pid:
+        return True
 
     import Quartz
+
+    # 若配置了 pid 但不匹配：允许用 titleHint 做 fallback（更稳的体验）
+    if cfg.pid is not None and not title_hint:
+        return False
+    if not title_hint:
+        return False
 
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
@@ -56,3 +60,37 @@ def is_target_frontmost(cfg: TargetWindowConfig) -> bool:
             continue
     return False
 
+
+def get_frontmost_debug(max_windows: int = 10) -> dict[str, object]:
+    """
+    返回前台应用与其窗口标题（用于 UI 调试）。
+    不保证窗口标题一定存在（很多窗口 kCGWindowName 为空）。
+    """
+    require_macos()
+    front = get_frontmost()
+
+    titles: list[str] = []
+    try:
+        import Quartz
+
+        wins = Quartz.CGWindowListCopyWindowInfo(
+            Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
+            Quartz.kCGNullWindowID,
+        )
+        for w in wins:
+            try:
+                owner_pid = int(w.get("kCGWindowOwnerPID", -1))
+                if owner_pid != front.pid:
+                    continue
+                title = str(w.get("kCGWindowName") or "").strip()
+                if not title:
+                    continue
+                titles.append(title)
+                if len(titles) >= max_windows:
+                    break
+            except Exception:
+                continue
+    except Exception:
+        titles = []
+
+    return {"pid": front.pid, "name": front.name, "windows": titles}


### PR DESCRIPTION
关联 Issue: #15

- UI 增加“查看日志”窗口：显示最近日志，支持打开/清空日志文件
- UI 增加“显示点位标记（调试）”：屏幕上彩色标识摇杆/视角/开火/开镜/背包/自定义点击坐标
- UI 补齐目标窗口配置（titleHint/PID）并提供“取前台”辅助
- 引擎补充关键日志：映射未启用/目标窗口未命中/模式非战斗等会明确提示

Closes #15
