### PR TITLE
关闭目标窗口检测开关 + 滚轮战斗/自由模式不同锚点

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
   "version": 1,
   "targetWindow": {
     "titleHint": "iPhone Mirroring",
+    "enabled": false,
     "pid": null,
     "windowId": null
   },
@@ -38,7 +39,7 @@
       },
       "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },
       "scope": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },
-      "wheel": { "enabled": true, "dPx": 8, "stopMs": 120, "invert": false, "rrandPx": null },
+      "wheel": { "enabled": true, "dPx": 8, "stopMs": 120, "invert": false, "anchorPoint": [800, 400], "rrandPx": null },
       "scheduler": {
         "tickHz": 120,
         "cameraMinHz": 50,

--- a/mirroring_keymap/cli.py
+++ b/mirroring_keymap/cli.py
@@ -28,6 +28,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
             "version": cfg.version,
             "targetWindow": {
                 "titleHint": cfg.targetWindow.titleHint,
+                "enabled": cfg.targetWindow.enabled,
                 "pid": cfg.targetWindow.pid,
                 "windowId": cfg.targetWindow.windowId,
             },

--- a/mirroring_keymap/default_config.py
+++ b/mirroring_keymap/default_config.py
@@ -8,6 +8,7 @@ DEFAULT_CONFIG_JSON = """\
   "version": 1,
   "targetWindow": {
     "titleHint": "iPhone Mirroring",
+    "enabled": false,
     "pid": null,
     "windowId": null
   },
@@ -44,7 +45,7 @@ DEFAULT_CONFIG_JSON = """\
       },
       "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },
       "scope": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },
-      "wheel": { "enabled": true, "dPx": 8, "stopMs": 120, "invert": false, "rrandPx": null },
+      "wheel": { "enabled": true, "dPx": 8, "stopMs": 120, "invert": false, "anchorPoint": [800, 400], "rrandPx": null },
       "scheduler": {
         "tickHz": 120,
         "cameraMinHz": 50,


### PR DESCRIPTION
关联 Issue: #17

- 新增 targetWindow.enabled：关闭后跳过目标窗口检测（映射启用即生效）
- 新增 wheel.anchorPoint：战斗模式下滚轮固定用该坐标拖动；自由鼠标下用鼠标当前位置拖动并回位
- UI 支持配置上述字段

Closes #17
