### PR TITLE
修复：UI 配置立即生效 + 点击点位蓝/橙标识 + 默认关闭目标窗口检测

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ pip install -e .
 
 ## 快速开始
 
-1) 复制并编辑示例配置：
+1) 复制并编辑示例配置（推荐放到默认路径，避免相对路径在 `.app` 下落到 Resources）：
 
 ```bash
-cp config.example.json config.json
+mkdir -p ~/Library/Application\ Support/MirroringKeymap
+cp config.example.json ~/Library/Application\ Support/MirroringKeymap/config.json
 ```
 
 2) 干跑（只解析配置，不做任何捕获/注入）：
 
 ```bash
-mirroring-keymap --config config.json --dry-run
+mirroring-keymap --dry-run
 ```
 
 3) 取点（点击一次屏幕，打印坐标；用于填配置里的摇杆中心/视角锚点/开火/开镜/背包按钮等点位）：
@@ -45,7 +46,7 @@ mirroring-keymap pick
 4) 正式运行：
 
 ```bash
-mirroring-keymap --config config.json --run
+mirroring-keymap --run
 ```
 
 ## UI（macOS）
@@ -67,6 +68,15 @@ open dist/MirroringKeymap.app
 首次启动 UI 时，会在 `~/Library/Application Support/MirroringKeymap/config.json` 自动生成一份默认配置（点位为占位值），你可以在 UI 里点“打开”直接编辑。
 
 UI 支持直接修改常用参数并保存（配置档点位/部分手感参数/全局热键），也支持在“自定义点击”里新增多条 `按键 -> 点击坐标` 映射。
+
+运行日志默认写入：
+
+- `~/Library/Logs/MirroringKeymap/mirroring_keymap.log`
+
+当勾选“显示点位标记（调试）”时：
+
+- 会显示关键点位/自定义点击点位
+- 当触发点击（开火/开镜/背包/自定义）时，会额外显示“实际点击点位”：蓝色表示最近一次点位，橙色表示按下状态
 
 ## 坐标说明
 

--- a/mirroring_keymap/config.py
+++ b/mirroring_keymap/config.py
@@ -23,7 +23,9 @@ def _as_point(v: Any, *, field: str) -> Point:
 class TargetWindowConfig:
     titleHint: str
     # 关闭后将跳过目标窗口检测（映射启用时对所有前台应用生效）
-    enabled: bool = True
+    # 默认关闭：iPhone Mirroring 的窗口识别在不同系统/语言环境下容易不稳定，
+    # 且会导致“目标窗口未命中 → 映射无反应”的误判。
+    enabled: bool = False
     pid: Optional[int] = None
     windowId: Optional[int] = None
 
@@ -137,7 +139,7 @@ def load_config(path: str | Path) -> AppConfig:
     if not isinstance(tw, dict):
         raise ValueError("targetWindow 必须是对象")
     title_hint = str(tw.get("titleHint") or "iPhone Mirroring")
-    enabled = bool(tw.get("enabled") if tw.get("enabled") is not None else True)
+    enabled = bool(tw.get("enabled") if tw.get("enabled") is not None else False)
     pid = tw.get("pid", None)
     pid_i = int(pid) if isinstance(pid, int) else None
     wid = tw.get("windowId", None)

--- a/mirroring_keymap/ui_app.py
+++ b/mirroring_keymap/ui_app.py
@@ -215,6 +215,15 @@ class UIApp:
         )
         return snap
 
+    def click_markers(self) -> list[dict[str, object]]:
+        rt = self._runtime
+        if rt is None:
+            return []
+        try:
+            return rt.engine.click_markers()
+        except Exception:
+            return []
+
     def set_mapping_enabled(self, enabled: bool) -> None:
         rt = self._runtime
         if rt is None:


### PR DESCRIPTION
关联 Issue: #19\n\n改动：\n- 默认关闭 targetWindow 检测（旧配置缺失 enabled 字段也默认关闭），避免误判导致无反应\n- UI：开始前自动保存当前表单；运行中保存后自动重启引擎以立即生效\n- 覆盖层：新增“实际点击点位”蓝/橙小圈（按下橙色，最近一次蓝色）\n- 日志：点击行为统一 INFO 输出；补充鼠标触发时被忽略原因；提示辅助功能权限缺失\n- CLI：默认 config 路径改为 ~/Library/Application Support/MirroringKeymap/config.json，并在缺失时自动生成默认配置\n\n生成的 .app：dist/MirroringKeymap.app（本地构建）