### PR TITLE
修复摇杆/背包/视角与 UI 可用性；启动清空日志

### DIFF
--- a/mirroring_keymap/macos/injector.py
+++ b/mirroring_keymap/macos/injector.py
@@ -86,13 +86,15 @@ class Injector:
         self.warp(pos)
         self._post_mouse(self._Quartz.kCGEventLeftMouseDragged, pos, self._Quartz.kCGMouseButtonLeft)
 
-    def drag_smooth(self, start: Point, end: Point, *, max_step_px: float) -> None:
+    def drag_smooth(self, start: Point, end: Point, *, max_step_px: float, step_delay_s: float = 0.0) -> None:
         if not self._left_down:
             self.left_down(start)
         cur = start
         for p in segment_points(start, end, max_step=max_step_px):
             cur = p
             self.left_drag(p)
+            if step_delay_s > 0:
+                time.sleep(step_delay_s)
         # 保持按住，由调用方决定何时 up
         _ = cur
 
@@ -114,4 +116,3 @@ class Injector:
     @property
     def user_data_tag(self) -> int:
         return self._user_data_tag
-


### PR DESCRIPTION
关联：#23 #24 #25 #26 #27

## 变更
- 引擎：FREE 模式也处理 Tap 队列，修复背包开关点击不执行
- 引擎：摇杆 Y 方向修正；增加最小按下/拖动时长与分段拖动延迟，提升 iPhone Mirroring/游戏端识别率
- 引擎：视角拖动增加按下窗口，并在覆盖层输出“视角拖动”标记
- 引擎：UI 前台时不吞输入（即时判断），避免点 UI 控件触发游戏点击
- UI：移除目标窗口相关 UI/提示；滚轮锚点标记改为读取当前 UI 表单值；避免与蓝/橙运行时标记混淆
- 日志：每次启动服务自动清空日志文件与 UI ring buffer

## 验收
- 双击 dist/MirroringKeymap.app 可启动（py2app）
- 战斗态下：WASD 驱动摇杆、鼠标驱动视角、Tab 背包开关都生效
- 点击/拖动会显示蓝圈位置，按下为橙圈
- 每次“启动服务”后日志从空开始
