### PR TITLE
修复：视角更丝滑 + 摇杆 WASD 生效 + 自定义按键录入

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ pip install -e .
 
 ## 快速开始
 
-1) 复制并编辑示例配置（推荐放到默认路径，避免相对路径在 `.app` 下落到 Resources）：
+1) 推荐直接使用 UI 配置（首次启动会自动生成默认配置到用户目录，UI 内修改并保存即可）。
+
+如需命令行/手工编辑，也可以把示例配置复制到默认路径：
 
 ```bash
 mkdir -p ~/Library/Application\ Support/MirroringKeymap
@@ -65,9 +67,9 @@ python -m mirroring_keymap.ui_main
 open dist/MirroringKeymap.app
 ```
 
-首次启动 UI 时，会在 `~/Library/Application Support/MirroringKeymap/config.json` 自动生成一份默认配置（点位为占位值），你可以在 UI 里点“打开”直接编辑。
+首次启动 UI 时，会在 `~/Library/Application Support/MirroringKeymap/config.json` 自动生成一份默认配置（点位为占位值）。后续推荐只通过 UI 修改并保存（无需手工编辑 config.json）。
 
-UI 支持直接修改常用参数并保存（配置档点位/部分手感参数/全局热键），也支持在“自定义点击”里新增多条 `按键 -> 点击坐标` 映射。
+UI 支持直接修改点位/手感参数/全局热键，也支持在“自定义点击”里新增多条 `按键 -> 点击坐标` 映射。
 
 运行日志默认写入：
 
@@ -80,11 +82,11 @@ UI 支持直接修改常用参数并保存（配置档点位/部分手感参数/
 
 ## 坐标说明
 
-当前实现使用 Quartz 全局坐标系（与 `CGEventGetLocation`/`CGWarpMouseCursorPosition` 一致，通常 **原点在主屏左下角**，单位为 points）。建议用 `mirroring-keymap pick` 取点，避免手工换算。
+当前实现使用 Quartz 全局坐标系（与 `CGEventGetLocation`/`CGWarpMouseCursorPosition` 一致，**原点在主屏左上角，Y 向下**，单位为 points）。建议用 `mirroring-keymap pick` 或 UI 的“取点”功能取点，避免手工换算。
 
 ## 默认热键（可在配置中修改）
 
 - 启用/禁用映射：`F8`
 - 紧急停止：`F12`（立即抬起所有按住并恢复光标）
-- 视角锁定：`CapsLock`（战斗/自由鼠标切换）
-- 背包：`Tab`（打开进入自由鼠标；关闭自动回战斗）
+- 视角锁定：`Tab`（战斗/自由鼠标切换）
+- 背包：`B`（打开进入自由鼠标；关闭自动回战斗）

--- a/config.example.json
+++ b/config.example.json
@@ -9,8 +9,8 @@
   "global": {
     "enableHotkey": "F8",
     "panicHotkey": "F12",
-    "cameraLockKey": "CapsLock",
-    "backpackKey": "Tab",
+    "cameraLockKey": "Tab",
+    "backpackKey": "B",
     "moveUpKey": "W",
     "moveDownKey": "S",
     "moveLeftKey": "A",
@@ -34,7 +34,7 @@
         "tcamPx": 3,
         "radiusPx": 80,
         "invertY": false,
-        "thresholdPx": 10.0,
+        "thresholdPx": 6.0,
         "rrandPx": null
       },
       "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },

--- a/config.example.json
+++ b/config.example.json
@@ -34,7 +34,7 @@
         "tcamPx": 3,
         "radiusPx": 80,
         "invertY": false,
-        "sensitivity": 1.0,
+        "thresholdPx": 10.0,
         "rrandPx": null
       },
       "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },

--- a/mirroring_keymap/config.py
+++ b/mirroring_keymap/config.py
@@ -34,8 +34,10 @@ class TargetWindowConfig:
 class GlobalConfig:
     enableHotkey: str = "F8"
     panicHotkey: str = "F12"
-    cameraLockKey: str = "CapsLock"
-    backpackKey: str = "Tab"
+    # 视角锁定切换键（用户更常用 Tab；CapsLock 作为可选）
+    cameraLockKey: str = "Tab"
+    # 背包/菜单切换键（建议不要与 cameraLockKey 冲突）
+    backpackKey: str = "B"
     # 移动摇杆方向键（默认 WASD）
     moveUpKey: str = "W"
     moveDownKey: str = "S"
@@ -62,7 +64,7 @@ class CameraConfig:
     # 视角拖动“阈值/平滑度”：
     # - 引擎会把鼠标累计位移按该阈值分段消耗（每次最多消耗 thresholdPx）
     # - 阈值越小越丝滑（但转动更慢）；阈值越大越灵敏（但更容易突兀）
-    thresholdPx: float = 10.0
+    thresholdPx: float = 6.0
     rrandPx: Optional[float] = None
 
 
@@ -155,8 +157,8 @@ def load_config(path: str | Path) -> AppConfig:
     global_cfg = GlobalConfig(
         enableHotkey=str(g.get("enableHotkey") or "F8"),
         panicHotkey=str(g.get("panicHotkey") or "F12"),
-        cameraLockKey=str(g.get("cameraLockKey") or "CapsLock"),
-        backpackKey=str(g.get("backpackKey") or "Tab"),
+        cameraLockKey=str(g.get("cameraLockKey") or "Tab"),
+        backpackKey=str(g.get("backpackKey") or "B"),
         moveUpKey=str(g.get("moveUpKey") or "W"),
         moveDownKey=str(g.get("moveDownKey") or "S"),
         moveLeftKey=str(g.get("moveLeftKey") or "A"),
@@ -225,7 +227,7 @@ def load_config(path: str | Path) -> AppConfig:
                 camera_raw.get("thresholdPx")
                 # 兼容旧字段：sensitivity（将其映射为阈值倍率）
                 if camera_raw.get("thresholdPx") is not None
-                else (float(camera_raw.get("sensitivity") or 1.0) * 10.0)
+                else (float(camera_raw.get("sensitivity") or 1.0) * 6.0)
             ),
             rrandPx=(float(camera_raw["rrandPx"]) if camera_raw.get("rrandPx") is not None else None),
         )

--- a/mirroring_keymap/config.py
+++ b/mirroring_keymap/config.py
@@ -59,7 +59,10 @@ class CameraConfig:
     tcamPx: float = 3.0
     radiusPx: float = 80.0
     invertY: bool = False
-    sensitivity: float = 1.0
+    # 视角拖动“阈值/平滑度”：
+    # - 引擎会把鼠标累计位移按该阈值分段消耗（每次最多消耗 thresholdPx）
+    # - 阈值越小越丝滑（但转动更慢）；阈值越大越灵敏（但更容易突兀）
+    thresholdPx: float = 10.0
     rrandPx: Optional[float] = None
 
 
@@ -217,7 +220,13 @@ def load_config(path: str | Path) -> AppConfig:
             tcamPx=float(camera_raw.get("tcamPx") or 3.0),
             radiusPx=float(camera_raw.get("radiusPx") or 80.0),
             invertY=bool(camera_raw.get("invertY") or False),
-            sensitivity=float(camera_raw.get("sensitivity") or 1.0),
+            thresholdPx=float(
+                # 新字段：thresholdPx
+                camera_raw.get("thresholdPx")
+                # 兼容旧字段：sensitivity（将其映射为阈值倍率）
+                if camera_raw.get("thresholdPx") is not None
+                else (float(camera_raw.get("sensitivity") or 1.0) * 10.0)
+            ),
             rrandPx=(float(camera_raw["rrandPx"]) if camera_raw.get("rrandPx") is not None else None),
         )
         fire = ActionConfig(

--- a/mirroring_keymap/default_config.py
+++ b/mirroring_keymap/default_config.py
@@ -15,8 +15,8 @@ DEFAULT_CONFIG_JSON = """\
   "global": {
     "enableHotkey": "F8",
     "panicHotkey": "F12",
-    "cameraLockKey": "CapsLock",
-    "backpackKey": "Tab",
+    "cameraLockKey": "Tab",
+    "backpackKey": "B",
     "moveUpKey": "W",
     "moveDownKey": "S",
     "moveLeftKey": "A",
@@ -40,7 +40,7 @@ DEFAULT_CONFIG_JSON = """\
         "tcamPx": 3,
         "radiusPx": 80,
         "invertY": false,
-        "thresholdPx": 10.0,
+        "thresholdPx": 6.0,
         "rrandPx": null
       },
       "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },

--- a/mirroring_keymap/default_config.py
+++ b/mirroring_keymap/default_config.py
@@ -40,7 +40,7 @@ DEFAULT_CONFIG_JSON = """\
         "tcamPx": 3,
         "radiusPx": 80,
         "invertY": false,
-        "sensitivity": 1.0,
+        "thresholdPx": 10.0,
         "rrandPx": null
       },
       "fire": { "mode": "tap", "tapHoldMs": 30, "rrandPx": null },

--- a/mirroring_keymap/macos/injector.py
+++ b/mirroring_keymap/macos/injector.py
@@ -25,6 +25,7 @@ class Injector:
         self._user_data_tag = int(user_data_tag)
         self._cursor_hidden = False
         self._left_down = False
+        self._last_post_pos: Optional[Point] = None
 
     def _mark_event(self, event) -> None:
         # 尝试在事件上打标，供 InputCapture 过滤回流。
@@ -38,7 +39,38 @@ class Injector:
         Q = self._Quartz
         ev = Q.CGEventCreateMouseEvent(None, event_type, pos, button)
         self._mark_event(ev)
+        # 显式设置 delta，避免某些消费端（例如 iPhone Mirroring）在“抬起→重新按下”时
+        # 依据系统内部 lastPos 计算出异常的大反向 delta。
+        try:
+            # Down/Up 本身不应该携带“跨位置的 delta”，否则可能被错误解释为拖动。
+            if event_type in (
+                Q.kCGEventLeftMouseDown,
+                Q.kCGEventLeftMouseUp,
+                Q.kCGEventRightMouseDown,
+                Q.kCGEventRightMouseUp,
+                getattr(Q, "kCGEventOtherMouseDown", -1),
+                getattr(Q, "kCGEventOtherMouseUp", -1),
+            ):
+                dx = 0
+                dy = 0
+            else:
+                if self._last_post_pos is None:
+                    dx = 0
+                    dy = 0
+                else:
+                    dx = int(round(float(pos[0]) - float(self._last_post_pos[0])))
+                    dy = int(round(float(pos[1]) - float(self._last_post_pos[1])))
+            Q.CGEventSetIntegerValueField(ev, Q.kCGMouseEventDeltaX, dx)
+            Q.CGEventSetIntegerValueField(ev, Q.kCGMouseEventDeltaY, dy)
+            # 尽量也填 unaccelerated（若常量存在）
+            if hasattr(Q, "kCGMouseEventUnacceleratedDeltaX"):
+                Q.CGEventSetIntegerValueField(ev, Q.kCGMouseEventUnacceleratedDeltaX, dx)
+            if hasattr(Q, "kCGMouseEventUnacceleratedDeltaY"):
+                Q.CGEventSetIntegerValueField(ev, Q.kCGMouseEventUnacceleratedDeltaY, dy)
+        except Exception:
+            pass
         Q.CGEventPost(Q.kCGHIDEventTap, ev)
+        self._last_post_pos = (float(pos[0]), float(pos[1]))
 
     def get_cursor_pos(self) -> Point:
         Q = self._Quartz
@@ -48,6 +80,8 @@ class Injector:
 
     def warp(self, pos: Point) -> None:
         self._Quartz.CGWarpMouseCursorPosition(pos)
+        # 与 _post_mouse 保持一致，避免之后 delta 计算跳变过大
+        self._last_post_pos = (float(pos[0]), float(pos[1]))
 
     def hide_cursor(self) -> None:
         if self._cursor_hidden:
@@ -72,19 +106,30 @@ class Injector:
         self.warp(snap.pos)
 
     def left_down(self, pos: Point) -> None:
-        self.warp(pos)
+        # 不要在注入前 warp 光标：
+        # - CGWarpMouseCursorPosition 可能触发系统生成的 mouseMoved 事件（无法打标），
+        #   导致引擎把“自己的注入”误当成真实鼠标输入，从而抢占/打断摇杆与视角服务。
+        # - 直接依赖 CGEventCreateMouseEvent 的位置参数即可。
         self._post_mouse(self._Quartz.kCGEventLeftMouseDown, pos, self._Quartz.kCGMouseButtonLeft)
         self._left_down = True
 
     def left_up(self, pos: Point) -> None:
-        self.warp(pos)
+        # 同 left_down：避免 warp 产生未打标事件。
         self._post_mouse(self._Quartz.kCGEventLeftMouseUp, pos, self._Quartz.kCGMouseButtonLeft)
         self._left_down = False
 
     def left_drag(self, pos: Point) -> None:
         # 注意：drag 事件隐含“左键按下”，因此要求外部先确保 left_down。
-        self.warp(pos)
+        # 同 left_down：避免 warp 产生未打标事件。
         self._post_mouse(self._Quartz.kCGEventLeftMouseDragged, pos, self._Quartz.kCGMouseButtonLeft)
+
+    def move_cursor(self, pos: Point) -> None:
+        """
+        将系统光标移动到指定位置（通过 mouseMoved 事件，而不是 CGWarpMouseCursorPosition）。
+        用途：在“视角触点到边界回中”时，先在抬起状态下把光标移回锚点，避免被 iPhone Mirroring
+        误判为“按住状态下的反向拖动”。
+        """
+        self._post_mouse(self._Quartz.kCGEventMouseMoved, pos, self._Quartz.kCGMouseButtonLeft)
 
     def drag_smooth(self, start: Point, end: Point, *, max_step_px: float, step_delay_s: float = 0.0) -> None:
         if not self._left_down:

--- a/mirroring_keymap/macos/keycodes.py
+++ b/mirroring_keymap/macos/keycodes.py
@@ -75,6 +75,8 @@ KEYCODES: dict[str, int] = {
     "0": 29,
 }
 
+_KEYCODES_REV: dict[int, str] = {v: k for k, v in KEYCODES.items()}
+
 
 def keycode_for(name: str) -> int:
     key = name.strip()
@@ -83,3 +85,11 @@ def keycode_for(name: str) -> int:
     if key not in KEYCODES:
         raise ValueError(f"未知按键: {name!r}（当前仅支持: {', '.join(sorted(KEYCODES))}）")
     return KEYCODES[key]
+
+
+def name_for_keycode(keycode: int) -> str:
+    """
+    反查 keycode 对应的键名（用于 UI “按键录入”）。
+    若未收录则返回空串，交由调用方提示用户。
+    """
+    return _KEYCODES_REV.get(int(keycode), "")

--- a/mirroring_keymap/ui_app.py
+++ b/mirroring_keymap/ui_app.py
@@ -72,6 +72,7 @@ class UIApp:
             self._log_path.parent.mkdir(parents=True, exist_ok=True)
             fh = RotatingFileHandler(
                 str(self._log_path),
+                mode="w",  # 每次启动清空旧日志，便于定位“本次启动”的问题
                 maxBytes=512 * 1024,
                 backupCount=3,
                 encoding="utf-8",

--- a/mirroring_keymap/ui_cocoa.py
+++ b/mirroring_keymap/ui_cocoa.py
@@ -67,8 +67,10 @@ class _MarkerView(NSView):
             pass
 
     def isFlipped(self):  # type: ignore[override]
-        # 与 Quartz 的屏幕坐标保持一致：原点左上，Y 向下
-        return True
+        # 使用 AppKit 默认坐标系（原点左下，Y 向上）。
+        # 由 _MarkerOverlay.update 负责把 Quartz 全局坐标（原点左上，Y 向下）
+        # 转换为本视图坐标，避免不同 pyobjc 版本下 flipped 行为差异导致偏移。
+        return False
 
     def drawRect_(self, rect) -> None:  # type: ignore[override]
         # 透明覆盖层，仅绘制点位标记
@@ -190,7 +192,7 @@ class _MarkerOverlay:
         if not self._windows:
             return
 
-        # 按屏幕分发坐标（Quartz 全局 -> 每屏局部）
+        # 按屏幕分发坐标（Quartz 全局 -> 每屏局部 -> AppKit 本地）
         per_view: list[list[dict]] = [[] for _ in self._views]
         for m in markers_global:
             try:
@@ -203,7 +205,8 @@ class _MarkerOverlay:
                 if gx >= bx and gx <= bx + bw and gy >= by and gy <= by + bh:
                     mm = dict(m)
                     mm["x"] = gx - bx
-                    mm["y"] = gy - by
+                    # 转换到 AppKit 视图坐标：origin=左下，Y 向上
+                    mm["y"] = bh - (gy - by)
                     per_view[idx].append(mm)
                     break
 
@@ -239,7 +242,6 @@ class AppDelegate(NSObject):
 
         self._pick_tap = None
         self._last_pick = None
-        self._key_capture = None  # (tap, src, target_field)
 
         # 配置编辑控件引用
         self._cfg_dict = None
@@ -405,14 +407,62 @@ class AppDelegate(NSObject):
             lbl.setStringValue_(text)
             return lbl
 
-        # 顶部：不暴露/不选择配置文件（设置以 UI 为准，自动持久化到用户目录）
-        content.addSubview_(_label("设置会自动保存（无需选择配置文件）", 20, 620, 420))
-        # Profile + 保存/重载
-        self._profile_popup = NSPopUpButton.alloc().initWithFrame_pullsDown_(NSMakeRect(20, 590, 220, 26), False)
-        self._profile_popup.setTarget_(self)
-        self._profile_popup.setAction_("onProfileChanged:")
-        content.addSubview_(self._profile_popup)
-        content.addSubview_(_label("配置档", 250, 590, 80))
+        # 按键下拉选项：不再使用“录入”，避免焦点/输入框占用导致误操作。
+        # 选项严格对应当前引擎支持的键名（keycodes.KEYCODES + MouseLeft/MouseRight）。
+        try:
+            from mirroring_keymap.macos.keycodes import KEYCODES
+        except Exception:
+            KEYCODES = {}  # type: ignore[assignment]
+
+        def _key_sort_key(name: str) -> tuple:
+            # F1..F12
+            if name.startswith("F") and name[1:].isdigit():
+                return (0, int(name[1:]))
+            # letters
+            if len(name) == 1 and name.isalpha():
+                return (1, name)
+            # digits
+            if len(name) == 1 and name.isdigit():
+                return (2, name)
+            # common specials (manual order)
+            special = {
+                "Tab": 0,
+                "Space": 1,
+                "Escape": 2,
+                "CapsLock": 3,
+                "Shift": 4,
+                "Control": 5,
+                "Option": 6,
+                "LeftArrow": 7,
+                "RightArrow": 8,
+                "UpArrow": 9,
+                "DownArrow": 10,
+            }
+            return (3, special.get(name, 999), name)
+
+        _keyboard_keys = sorted([str(k) for k in getattr(KEYCODES, "keys", lambda: [])()], key=_key_sort_key)
+        _keys_with_mouse = ["MouseLeft", "MouseRight"] + _keyboard_keys
+
+        def _key_popup(rect, *, include_mouse: bool) -> NSPopUpButton:
+            p = NSPopUpButton.alloc().initWithFrame_pullsDown_(rect, False)
+            titles = _keys_with_mouse if include_mouse else _keyboard_keys
+            try:
+                p.addItemsWithTitles_(titles)
+            except Exception:
+                # 某些 pyobjc 版本下 addItemsWithTitles_ 可能不稳定，退化为逐个 addItemWithTitle_
+                for t in titles:
+                    try:
+                        p.addItemWithTitle_(t)
+                    except Exception:
+                        pass
+            return p
+
+        # 顶部：不暴露/不选择配置文件/配置档（设置以 UI 为准，自动持久化到用户目录）
+        content.addSubview_(_label("设置会自动保存（无需选择配置文件/配置档）", 20, 620, 520))
+        try:
+            content.addSubview_(_label(f"保存位置：{self._cfg_path()}", 20, 592, 640))
+        except Exception:
+            content.addSubview_(_label("保存位置：~/Library/Application Support/MirroringKeymap/config.json", 20, 592, 640))
 
         btn_save = NSButton.alloc().initWithFrame_(NSMakeRect(680, 588, 100, 28))
         btn_save.setTitle_("保存设置")
@@ -506,7 +556,7 @@ class AppDelegate(NSObject):
         content.addSubview_(self._lbl_pick)
 
         # --------------------
-        # 分页设置：把“点位/参数/按键/自定义”按类别分开，避免挤在同一屏；
+        # 分页设置：把“点位/参数/自定义”按类别分开，避免挤在同一屏；
         # 同时每页使用 ScrollView，窗口缩小后仍可滚动查看全部设置。
         self._tab = NSTabView.alloc().initWithFrame_(NSMakeRect(20, 70, 870, 355))
         self._tab.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
@@ -537,9 +587,28 @@ class AppDelegate(NSObject):
         # Tab 1: 点位
         # --------------------
         doc_points = _add_tab("points", "点位", 860, 360)
-        doc_points.addSubview_(_label("关键点位（屏幕全局坐标）", 20, 325, 300))
+        doc_points.addSubview_(_label("点位 + 对应按键（屏幕全局坐标）", 20, 325, 300))
+
+        # 全局热键/通用参数（放在同一页，避免“按键页”和“点位页”来回切）
+        doc_points.addSubview_(_label("启用", 520, 327, 35))
+        self._global_enable_hotkey = _key_popup(NSMakeRect(555, 320, 70, 26), include_mouse=False)
+        doc_points.addSubview_(self._global_enable_hotkey)
+
+        doc_points.addSubview_(_label("紧急", 635, 327, 35))
+        self._global_panic_hotkey = _key_popup(NSMakeRect(670, 320, 70, 26), include_mouse=False)
+        doc_points.addSubview_(self._global_panic_hotkey)
+
+        doc_points.addSubview_(_label("随机", 750, 327, 35))
+        self._global_rrand_default = NSTextField.alloc().initWithFrame_(NSMakeRect(785, 322, 55, 24))
+        doc_points.addSubview_(self._global_rrand_default)
+
         doc_points.addSubview_(_label("X", 170, 295, 20))
         doc_points.addSubview_(_label("Y", 290, 295, 20))
+        doc_points.addSubview_(_label("键", 520, 295, 18))
+        doc_points.addSubview_(_label("上", 545, 295, 18))
+        doc_points.addSubview_(_label("下", 595, 295, 18))
+        doc_points.addSubview_(_label("左", 645, 295, 18))
+        doc_points.addSubview_(_label("右", 695, 295, 18))
 
         self._point_fields = {}
         point_defs = [
@@ -565,8 +634,37 @@ class AppDelegate(NSObject):
             doc_points.addSubview_(btn_fill)
             self._point_fields[key] = (fx, fy)
 
+            # 对应按键设置：跟随点位展示（用户诉求：按键设置与点位设置合并）
+            if key == "joystickCenter":
+                self._global_move_up_key = _key_popup(NSMakeRect(540, y - 1, 55, 26), include_mouse=False)
+                self._global_move_down_key = _key_popup(NSMakeRect(595, y - 1, 55, 26), include_mouse=False)
+                self._global_move_left_key = _key_popup(NSMakeRect(650, y - 1, 55, 26), include_mouse=False)
+                self._global_move_right_key = _key_popup(NSMakeRect(705, y - 1, 55, 26), include_mouse=False)
+                doc_points.addSubview_(self._global_move_up_key)
+                doc_points.addSubview_(self._global_move_down_key)
+                doc_points.addSubview_(self._global_move_left_key)
+                doc_points.addSubview_(self._global_move_right_key)
+            elif key == "cameraAnchor":
+                self._global_camera_lock_key = _key_popup(NSMakeRect(540, y - 1, 160, 26), include_mouse=False)
+                doc_points.addSubview_(self._global_camera_lock_key)
+            elif key == "fire":
+                self._global_fire_key = _key_popup(NSMakeRect(540, y - 1, 160, 26), include_mouse=True)
+                doc_points.addSubview_(self._global_fire_key)
+            elif key == "scope":
+                self._global_scope_key = _key_popup(NSMakeRect(540, y - 1, 160, 26), include_mouse=True)
+                doc_points.addSubview_(self._global_scope_key)
+            elif key == "backpack":
+                self._global_backpack_key = _key_popup(NSMakeRect(540, y - 1, 160, 26), include_mouse=False)
+                doc_points.addSubview_(self._global_backpack_key)
+
         doc_points.addSubview_(
-            _label("提示：先点“取点”，再点每行的“填入取点”。坐标是屏幕全局坐标（非窗口相对）。", 20, 20, 820)
+            _label(
+                "提示：先点“取点”，再点每行的“填入取点”。坐标是屏幕全局坐标（原点左上，Y 向下；非窗口相对）。"
+                " 键：支持 MouseLeft/MouseRight 或键盘按键名（如 E/Space/Tab）。",
+                20,
+                20,
+                820,
+            )
         )
 
         # --------------------
@@ -640,53 +738,7 @@ class AppDelegate(NSObject):
         doc_params.addSubview_(self._sched_max_step)
 
         # --------------------
-        # Tab 3: 按键
-        # --------------------
-        doc_keys = _add_tab("keys", "按键", 860, 360)
-        doc_keys.addSubview_(_label("按键设置（全局）", 20, 325, 200))
-
-        doc_keys.addSubview_(_label("启用热键", 20, 285, 60))
-        self._global_enable_hotkey = NSTextField.alloc().initWithFrame_(NSMakeRect(80, 280, 70, 24))
-        doc_keys.addSubview_(self._global_enable_hotkey)
-
-        doc_keys.addSubview_(_label("紧急热键", 170, 285, 60))
-        self._global_panic_hotkey = NSTextField.alloc().initWithFrame_(NSMakeRect(230, 280, 70, 24))
-        doc_keys.addSubview_(self._global_panic_hotkey)
-
-        doc_keys.addSubview_(_label("开火键", 320, 285, 45))
-        self._global_fire_key = NSTextField.alloc().initWithFrame_(NSMakeRect(365, 280, 90, 24))
-        doc_keys.addSubview_(self._global_fire_key)
-
-        doc_keys.addSubview_(_label("开镜键", 470, 285, 45))
-        self._global_scope_key = NSTextField.alloc().initWithFrame_(NSMakeRect(515, 280, 90, 24))
-        doc_keys.addSubview_(self._global_scope_key)
-
-        doc_keys.addSubview_(_label("视角锁定键", 20, 245, 80))
-        self._global_camera_lock_key = NSTextField.alloc().initWithFrame_(NSMakeRect(100, 240, 90, 24))
-        doc_keys.addSubview_(self._global_camera_lock_key)
-
-        doc_keys.addSubview_(_label("背包键", 210, 245, 45))
-        self._global_backpack_key = NSTextField.alloc().initWithFrame_(NSMakeRect(255, 240, 90, 24))
-        doc_keys.addSubview_(self._global_backpack_key)
-
-        doc_keys.addSubview_(_label("移动(上/下/左/右)", 20, 205, 110))
-        self._global_move_up_key = NSTextField.alloc().initWithFrame_(NSMakeRect(135, 200, 40, 24))
-        self._global_move_down_key = NSTextField.alloc().initWithFrame_(NSMakeRect(185, 200, 40, 24))
-        self._global_move_left_key = NSTextField.alloc().initWithFrame_(NSMakeRect(235, 200, 40, 24))
-        self._global_move_right_key = NSTextField.alloc().initWithFrame_(NSMakeRect(285, 200, 40, 24))
-        doc_keys.addSubview_(self._global_move_up_key)
-        doc_keys.addSubview_(self._global_move_down_key)
-        doc_keys.addSubview_(self._global_move_left_key)
-        doc_keys.addSubview_(self._global_move_right_key)
-
-        doc_keys.addSubview_(_label("随机半径默认(px)", 20, 165, 100))
-        self._global_rrand_default = NSTextField.alloc().initWithFrame_(NSMakeRect(120, 160, 70, 24))
-        doc_keys.addSubview_(self._global_rrand_default)
-
-        doc_keys.addSubview_(_label("提示：MouseLeft/MouseRight 表示鼠标左右键。", 20, 20, 820))
-
-        # --------------------
-        # Tab 4: 自定义
+        # Tab 3: 自定义
         # --------------------
         doc_custom = _add_tab("custom", "自定义", 860, 420)
         doc_custom.addSubview_(_label("自定义点击（按键→点击）", 20, 385, 240))
@@ -696,17 +748,14 @@ class AppDelegate(NSObject):
         doc_custom.addSubview_(self._custom_name)
 
         doc_custom.addSubview_(_label("键", 295, 345, 20))
-        self._custom_key = NSTextField.alloc().initWithFrame_(NSMakeRect(315, 340, 90, 24))
+        self._custom_key = _key_popup(NSMakeRect(315, 339, 160, 26), include_mouse=False)
         doc_custom.addSubview_(self._custom_key)
+        try:
+            self._custom_key.selectItemWithTitle_("E")
+        except Exception:
+            pass
 
-        btn_capture_key = NSButton.alloc().initWithFrame_(NSMakeRect(410, 339, 60, 26))
-        btn_capture_key.setTitle_("录入")
-        btn_capture_key.setBezelStyle_(NSBezelStyleRounded)
-        btn_capture_key.setTarget_(self)
-        btn_capture_key.setAction_("onCaptureCustomKey:")
-        doc_custom.addSubview_(btn_capture_key)
-
-        btn_add = NSButton.alloc().initWithFrame_(NSMakeRect(475, 339, 120, 26))
+        btn_add = NSButton.alloc().initWithFrame_(NSMakeRect(480, 339, 120, 26))
         btn_add.setTitle_("添加/替换")
         btn_add.setBezelStyle_(NSBezelStyleRounded)
         btn_add.setTarget_(self)
@@ -720,12 +769,19 @@ class AppDelegate(NSObject):
         self._custom_y = NSTextField.alloc().initWithFrame_(NSMakeRect(140, 300, 80, 24))
         doc_custom.addSubview_(self._custom_y)
 
-        doc_custom.addSubview_(_label("按压(ms)", 235, 305, 55))
-        self._custom_hold = NSTextField.alloc().initWithFrame_(NSMakeRect(290, 300, 70, 24))
+        btn_fill_custom = NSButton.alloc().initWithFrame_(NSMakeRect(235, 299, 100, 26))
+        btn_fill_custom.setTitle_("填入取点")
+        btn_fill_custom.setBezelStyle_(NSBezelStyleRounded)
+        btn_fill_custom.setTarget_(self)
+        btn_fill_custom.setAction_("onFillCustomPoint:")
+        doc_custom.addSubview_(btn_fill_custom)
+
+        doc_custom.addSubview_(_label("按压(ms)", 350, 305, 55))
+        self._custom_hold = NSTextField.alloc().initWithFrame_(NSMakeRect(405, 300, 70, 24))
         doc_custom.addSubview_(self._custom_hold)
 
-        doc_custom.addSubview_(_label("随机(px)", 375, 305, 50))
-        self._custom_rrand = NSTextField.alloc().initWithFrame_(NSMakeRect(425, 300, 70, 24))
+        doc_custom.addSubview_(_label("随机(px)", 485, 305, 50))
+        self._custom_rrand = NSTextField.alloc().initWithFrame_(NSMakeRect(535, 300, 70, 24))
         doc_custom.addSubview_(self._custom_rrand)
 
         doc_custom.addSubview_(_label("删除编号(1-based)", 20, 265, 95))
@@ -778,8 +834,8 @@ class AppDelegate(NSObject):
 
     @objc.python_method
     def _selected_profile(self) -> Optional[str]:
-        name = str(self._profile_popup.titleOfSelectedItem() or "").strip()
-        return name or None
+        # UI 不提供“配置档/Profiles”选择：始终使用第一个 profile
+        return None
 
     @objc.python_method
     def _ensure_log_window(self) -> None:
@@ -978,6 +1034,52 @@ class AppDelegate(NSObject):
         return k
 
     @objc.python_method
+    def _set_key_control(self, ctrl, value: str, default: str) -> None:
+        """
+        兼容两种 UI 控件：
+        - NSPopUpButton：用 selectItemWithTitle_
+        - NSTextField：用 setStringValue_
+        """
+        if ctrl is None:
+            return
+        v = str(value or "").strip() or str(default)
+        # 优先走下拉框
+        try:
+            ctrl.selectItemWithTitle_(v)
+            try:
+                if str(ctrl.titleOfSelectedItem() or "") != v:
+                    # 配置里可能有旧值：追加到末尾并选中
+                    ctrl.addItemWithTitle_(v)
+                    ctrl.selectItemWithTitle_(v)
+            except Exception:
+                pass
+            return
+        except Exception:
+            pass
+        # 回退：文本框
+        try:
+            ctrl.setStringValue_(v)
+        except Exception:
+            pass
+
+    @objc.python_method
+    def _get_key_control(self, ctrl, default: str) -> str:
+        if ctrl is None:
+            return str(default)
+        # 下拉框
+        try:
+            v = str(ctrl.titleOfSelectedItem() or "").strip()
+            return v or str(default)
+        except Exception:
+            pass
+        # 文本框
+        try:
+            v = str(ctrl.stringValue() or "").strip()
+            return v or str(default)
+        except Exception:
+            return str(default)
+
+    @objc.python_method
     def _profiles_list(self) -> list[dict]:
         if not isinstance(self._cfg_dict, dict):
             return []
@@ -1022,25 +1124,25 @@ class AppDelegate(NSObject):
             g = {}
 
         if self._global_enable_hotkey is not None:
-            self._global_enable_hotkey.setStringValue_(str(g.get("enableHotkey") or "F8"))
+            self._set_key_control(self._global_enable_hotkey, str(g.get("enableHotkey") or ""), "F8")
         if self._global_panic_hotkey is not None:
-            self._global_panic_hotkey.setStringValue_(str(g.get("panicHotkey") or "F12"))
+            self._set_key_control(self._global_panic_hotkey, str(g.get("panicHotkey") or ""), "F12")
         if self._global_camera_lock_key is not None:
-            self._global_camera_lock_key.setStringValue_(str(g.get("cameraLockKey") or "CapsLock"))
+            self._set_key_control(self._global_camera_lock_key, str(g.get("cameraLockKey") or ""), "Tab")
         if self._global_backpack_key is not None:
-            self._global_backpack_key.setStringValue_(str(g.get("backpackKey") or "Tab"))
+            self._set_key_control(self._global_backpack_key, str(g.get("backpackKey") or ""), "B")
         if self._global_move_up_key is not None:
-            self._global_move_up_key.setStringValue_(str(g.get("moveUpKey") or "W"))
+            self._set_key_control(self._global_move_up_key, str(g.get("moveUpKey") or ""), "W")
         if self._global_move_down_key is not None:
-            self._global_move_down_key.setStringValue_(str(g.get("moveDownKey") or "S"))
+            self._set_key_control(self._global_move_down_key, str(g.get("moveDownKey") or ""), "S")
         if self._global_move_left_key is not None:
-            self._global_move_left_key.setStringValue_(str(g.get("moveLeftKey") or "A"))
+            self._set_key_control(self._global_move_left_key, str(g.get("moveLeftKey") or ""), "A")
         if self._global_move_right_key is not None:
-            self._global_move_right_key.setStringValue_(str(g.get("moveRightKey") or "D"))
+            self._set_key_control(self._global_move_right_key, str(g.get("moveRightKey") or ""), "D")
         if self._global_fire_key is not None:
-            self._global_fire_key.setStringValue_(str(g.get("fireKey") or "MouseLeft"))
+            self._set_key_control(self._global_fire_key, str(g.get("fireKey") or ""), "MouseLeft")
         if self._global_scope_key is not None:
-            self._global_scope_key.setStringValue_(str(g.get("scopeKey") or "MouseRight"))
+            self._set_key_control(self._global_scope_key, str(g.get("scopeKey") or ""), "MouseRight")
         if self._global_rrand_default is not None:
             self._global_rrand_default.setStringValue_(str(g.get("rrandDefaultPx") if g.get("rrandDefaultPx") is not None else 0))
 
@@ -1084,10 +1186,10 @@ class AppDelegate(NSObject):
             thr = camera.get("thresholdPx")
             if thr is None and camera.get("sensitivity") is not None:
                 try:
-                    thr = float(camera.get("sensitivity")) * 10.0
+                    thr = float(camera.get("sensitivity")) * 6.0
                 except Exception:
                     thr = None
-            self._cam_thresh.setStringValue_(str(thr if thr is not None else 10.0))
+            self._cam_thresh.setStringValue_(str(thr if thr is not None else 6.0))
         if self._cam_invert is not None:
             self._cam_invert.setState_(1 if bool(camera.get("invertY")) else 0)
         if self._cam_tcam is not None:
@@ -1145,25 +1247,25 @@ class AppDelegate(NSObject):
             self._cfg_dict["global"] = g
 
         if self._global_enable_hotkey is not None:
-            g["enableHotkey"] = str(self._global_enable_hotkey.stringValue()).strip() or "F8"
+            g["enableHotkey"] = self._get_key_control(self._global_enable_hotkey, "F8")
         if self._global_panic_hotkey is not None:
-            g["panicHotkey"] = str(self._global_panic_hotkey.stringValue()).strip() or "F12"
+            g["panicHotkey"] = self._get_key_control(self._global_panic_hotkey, "F12")
         if self._global_camera_lock_key is not None:
-            g["cameraLockKey"] = str(self._global_camera_lock_key.stringValue()).strip() or "CapsLock"
+            g["cameraLockKey"] = self._get_key_control(self._global_camera_lock_key, "Tab")
         if self._global_backpack_key is not None:
-            g["backpackKey"] = str(self._global_backpack_key.stringValue()).strip() or "Tab"
+            g["backpackKey"] = self._get_key_control(self._global_backpack_key, "B")
         if self._global_move_up_key is not None:
-            g["moveUpKey"] = str(self._global_move_up_key.stringValue()).strip() or "W"
+            g["moveUpKey"] = self._get_key_control(self._global_move_up_key, "W")
         if self._global_move_down_key is not None:
-            g["moveDownKey"] = str(self._global_move_down_key.stringValue()).strip() or "S"
+            g["moveDownKey"] = self._get_key_control(self._global_move_down_key, "S")
         if self._global_move_left_key is not None:
-            g["moveLeftKey"] = str(self._global_move_left_key.stringValue()).strip() or "A"
+            g["moveLeftKey"] = self._get_key_control(self._global_move_left_key, "A")
         if self._global_move_right_key is not None:
-            g["moveRightKey"] = str(self._global_move_right_key.stringValue()).strip() or "D"
+            g["moveRightKey"] = self._get_key_control(self._global_move_right_key, "D")
         if self._global_fire_key is not None:
-            g["fireKey"] = str(self._global_fire_key.stringValue()).strip() or "MouseLeft"
+            g["fireKey"] = self._get_key_control(self._global_fire_key, "MouseLeft")
         if self._global_scope_key is not None:
-            g["scopeKey"] = str(self._global_scope_key.stringValue()).strip() or "MouseRight"
+            g["scopeKey"] = self._get_key_control(self._global_scope_key, "MouseRight")
         if self._global_rrand_default is not None:
             g["rrandDefaultPx"] = self._safe_float(self._global_rrand_default, 0.0)
 
@@ -1204,7 +1306,7 @@ class AppDelegate(NSObject):
         if self._joy_radius is not None:
             joystick["radiusPx"] = self._safe_float(self._joy_radius, 120.0)
         if self._cam_thresh is not None:
-            camera["thresholdPx"] = self._safe_float(self._cam_thresh, 10.0)
+            camera["thresholdPx"] = self._safe_float(self._cam_thresh, 6.0)
             # 清理旧字段，避免混淆
             camera.pop("sensitivity", None)
         if self._cam_invert is not None:
@@ -1251,7 +1353,6 @@ class AppDelegate(NSObject):
             ui["mappingEnabled"] = bool(self._chk_enabled.state()) if self._chk_enabled is not None else False
             ui["cameraLock"] = bool(self._chk_camera.state()) if self._chk_camera is not None else False
             ui["overlayEnabled"] = bool(self._chk_overlay.state()) if self._chk_overlay is not None else False
-            ui["lastProfile"] = self._selected_profile()
         except Exception:
             pass
 
@@ -1361,6 +1462,13 @@ class AppDelegate(NSObject):
             self._alert("检测失败", str(e))
 
     def onStart_(self, _sender) -> None:
+        # 避免焦点停留在某个输入框导致按键被“打字进去”
+        try:
+            if self._window is not None:
+                self._window.makeFirstResponder_(None)
+        except Exception:
+            pass
+
         # 启动前自动保存一次，确保“直接点开始”也能使用当前表单值
         if not self._save_current_config():
             return
@@ -1462,95 +1570,6 @@ class AppDelegate(NSObject):
 
         self._lbl_pick.setStringValue_("请在屏幕上点击一次以取点…")
 
-    def onCaptureCustomKey_(self, _sender) -> None:
-        """
-        自定义点击的“按键录入”：
-        点击“录入”后按下一次键盘按键，自动写入到自定义按键输入框。
-        """
-        if self._custom_key is None:
-            return
-        if self._key_capture is not None:
-            return
-        try:
-            import Quartz
-        except Exception as e:
-            self._alert("录入失败", f"无法导入 Quartz：{e}")
-            return
-
-        from mirroring_keymap.macos.keycodes import name_for_keycode
-
-        def _stop_capture() -> None:
-            try:
-                tap, src, _field = self._key_capture  # type: ignore[misc]
-            except Exception:
-                return
-            try:
-                Quartz.CGEventTapEnable(tap, False)
-            except Exception:
-                pass
-            try:
-                Quartz.CFRunLoopRemoveSource(Quartz.CFRunLoopGetCurrent(), src, Quartz.kCFRunLoopCommonModes)
-            except Exception:
-                pass
-            self._key_capture = None
-
-        def _cb(_proxy, event_type, event, _refcon):
-            if event_type == Quartz.kCGEventKeyDown:
-                kc = int(Quartz.CGEventGetIntegerValueField(event, Quartz.kCGKeyboardEventKeycode))
-                key_name = name_for_keycode(kc)
-                if not key_name:
-                    self._alert("录入失败", f"该按键暂不支持（keycode={kc}）。请换一个常用按键，或手动输入。")
-                    _stop_capture()
-                    return event
-                # Escape 作为取消键，不写入
-                if key_name == "Escape":
-                    _stop_capture()
-                    return event
-                try:
-                    self._custom_key.setStringValue_(key_name)
-                    # 解除焦点，避免输入框一直被占用
-                    try:
-                        if self._window is not None:
-                            self._window.makeFirstResponder_(None)
-                    except Exception:
-                        pass
-                except Exception:
-                    pass
-                _stop_capture()
-                return event
-
-            # 允许用户用鼠标点回窗口，但不支持鼠标键作为自定义触发键
-            if event_type in (Quartz.kCGEventLeftMouseDown, Quartz.kCGEventRightMouseDown):
-                self._alert("录入提示", "自定义点击暂不支持鼠标键，请按键盘按键。")
-                _stop_capture()
-                return event
-
-            return event
-
-        mask = 0
-        for et in (Quartz.kCGEventKeyDown, Quartz.kCGEventLeftMouseDown, Quartz.kCGEventRightMouseDown):
-            mask |= 1 << et
-        tap = Quartz.CGEventTapCreate(
-            Quartz.kCGHIDEventTap,
-            Quartz.kCGHeadInsertEventTap,
-            Quartz.kCGEventTapOptionListenOnly,
-            mask,
-            _cb,
-            None,
-        )
-        if tap is None:
-            self._alert("录入失败", "创建 EventTap 失败：请检查 Input Monitoring / Accessibility 权限。")
-            return
-        src = Quartz.CFMachPortCreateRunLoopSource(None, tap, 0)
-        Quartz.CFRunLoopAddSource(Quartz.CFRunLoopGetCurrent(), src, Quartz.kCFRunLoopCommonModes)
-        Quartz.CGEventTapEnable(tap, True)
-        self._key_capture = (tap, src, self._custom_key)
-
-        try:
-            self._lbl_pick.setStringValue_("按键录入：请按下要绑定的按键（按 Esc 取消）…")
-        except Exception:
-            pass
-
     @objc.python_method
     def _on_picked(self, x: float, y: float) -> None:
         self._last_pick = (x, y)
@@ -1586,38 +1605,18 @@ class AppDelegate(NSObject):
         except Exception:
             self._cfg_mtime = None
 
-        # 刷新 profile 列表
-        profiles = self._profiles_list()
-        names: list[str] = []
-        for i, p in enumerate(profiles):
-            if not isinstance(p, dict):
-                continue
-            nm = str(p.get("name") or f"配置档 {i+1}")
-            names.append(nm)
-            p["name"] = nm
-
-        if not names:
-            names = ["Default"]
-            if isinstance(self._cfg_dict, dict):
-                self._cfg_dict["profiles"] = [{"name": "Default", "points": {}}]
-
-        current = self._selected_profile()
-        desired = None
+        # UI 固定使用 profiles[0]，这里确保 profiles 至少有 1 个
         try:
-            ui = self._cfg_dict.get("ui") if isinstance(self._cfg_dict, dict) else None
-            if isinstance(ui, dict):
-                desired = str(ui.get("lastProfile") or "").strip() or None
+            if isinstance(self._cfg_dict, dict):
+                profiles = self._cfg_dict.get("profiles")
+                if not isinstance(profiles, list) or not profiles:
+                    self._cfg_dict["profiles"] = [{"name": "默认", "points": {}}]
+                else:
+                    p0 = profiles[0]
+                    if isinstance(p0, dict):
+                        p0["name"] = str(p0.get("name") or "默认")
         except Exception:
-            desired = None
-        self._profile_popup.removeAllItems()
-        for n in names:
-            self._profile_popup.addItemWithTitle_(n)
-        if current and current in names:
-            self._profile_popup.selectItemWithTitle_(current)
-        elif desired and desired in names:
-            self._profile_popup.selectItemWithTitle_(desired)
-        else:
-            self._profile_popup.selectItemAtIndex_(0)
+            pass
 
         # 同步表单
         self._sync_ui_from_cfg()
@@ -1642,6 +1641,17 @@ class AppDelegate(NSObject):
         path = self._cfg_path()
         try:
             self._apply_ui_to_cfg()
+            # 关键校验：锁定键与背包键不能相同，否则会出现“按一次同时触发两种行为”的混乱。
+            try:
+                g = self._cfg_dict.get("global") if isinstance(self._cfg_dict, dict) else None
+                if isinstance(g, dict):
+                    cam_k = str(g.get("cameraLockKey") or "").strip()
+                    bag_k = str(g.get("backpackKey") or "").strip()
+                    if cam_k and bag_k and cam_k == bag_k:
+                        self._alert("保存失败", "“视角锁定键”和“背包键”不能设置为同一个键，请修改其中一个。")
+                        return False
+            except Exception:
+                pass
             self._app.save_config_dict(path, self._cfg_dict)
         except Exception as e:
             self._alert("保存失败", str(e))
@@ -1662,6 +1672,12 @@ class AppDelegate(NSObject):
         return True
 
     def onSaveConfig_(self, _sender) -> None:
+        try:
+            if self._window is not None:
+                self._window.makeFirstResponder_(None)
+        except Exception:
+            pass
+
         snap = self._app.snapshot()
         was_running = bool(snap.get("running"))
         prev_mapping = bool(snap.get("mapping_enabled"))
@@ -1698,6 +1714,16 @@ class AppDelegate(NSObject):
         fx.setStringValue_(f"{x:.1f}")
         fy.setStringValue_(f"{y:.1f}")
 
+    def onFillCustomPoint_(self, _sender) -> None:
+        if self._last_pick is None:
+            self._alert("无法填入", "请先点击“取点（点击）”获取坐标。")
+            return
+        if self._custom_x is None or self._custom_y is None:
+            return
+        x, y = self._last_pick
+        self._custom_x.setStringValue_(f"{x:.1f}")
+        self._custom_y.setStringValue_(f"{y:.1f}")
+
     def onAddCustom_(self, _sender) -> None:
         if not isinstance(self._cfg_dict, dict):
             self.onReloadConfig_(None)
@@ -1705,9 +1731,9 @@ class AppDelegate(NSObject):
             return
 
         name = str(self._custom_name.stringValue() if self._custom_name else "").strip() or "Custom"
-        key = self._normalize_key(str(self._custom_key.stringValue() if self._custom_key else ""))
+        key = self._normalize_key(self._get_key_control(self._custom_key, "E"))
         if not key:
-            self._alert("新增失败", "请填写触发键（例如：E / R / Space / 1）。")
+            self._alert("新增失败", "请选择触发键（例如：E / R / Space / 1）。")
             return
 
         x_s = str(self._custom_x.stringValue() if self._custom_x else "").strip()
@@ -1804,8 +1830,7 @@ class AppDelegate(NSObject):
         if not snap.get("running"):
             self._lbl_status.setStringValue_(
                 "状态：未启动\n"
-                "提示：首次运行请在系统设置 → 隐私与安全性中开启“输入监控”和“辅助功能”权限；"
-                "点位坐标使用屏幕全局坐标；MouseLeft/MouseRight 表示鼠标左右键。"
+                "提示：首次运行请在系统设置 → 隐私与安全性中开启“输入监控”和“辅助功能”权限。"
             )
             self._btn_start.setEnabled_(True)
             self._btn_stop.setEnabled_(False)
@@ -1820,19 +1845,45 @@ class AppDelegate(NSObject):
         mode_map = {"paused": "暂停", "battle": "战斗", "free": "自由鼠标"}
         mode_cn = mode_map.get(str(snap.get("mode") or ""), str(snap.get("mode") or ""))
 
+        # 诊断：WASD 是否被捕获（EventTap/轮询）
+        def bit4(d: object) -> str:
+            if not isinstance(d, dict):
+                return "----"
+            try:
+                u = "1" if int(d.get("up") or 0) else "0"
+                l = "1" if int(d.get("left") or 0) else "0"
+                dn = "1" if int(d.get("down") or 0) else "0"
+                r = "1" if int(d.get("right") or 0) else "0"
+                return f"{u}{l}{dn}{r}"
+            except Exception:
+                return "----"
+
+        et_bits = bit4(snap.get("move_eventtap"))
+        pol_bits = bit4(snap.get("move_polled"))
+        poll_ok = yn(snap.get("poll_move_ok"))
+        secure = snap.get("secure_input")
+        secure_txt = "未知" if secure is None else yn(bool(secure))
+        age = snap.get("last_kbd_event_age_ms")
+        age_txt = "-" if age is None else f"{int(age)}ms"
+
         hint = ""
         if snap.get("accessibility_trusted") is False:
             hint = "提示：未授予“辅助功能”权限，可能无法注入点击/拖动。请到 系统设置 → 隐私与安全性 → 辅助功能 授权。"
+        elif secure is True:
+            hint = (
+                "提示：检测到系统已开启“安全输入”，第三方程序无法读取键盘事件，WASD 将无法工作。"
+                "请关闭可能开启安全输入的程序/输入框后重试。"
+            )
+        elif not bool(snap.get("target_active")):
+            hint = "提示：为避免误触，当前前台为本程序时会自动暂停映射。请切换到 iPhone Mirroring/游戏窗口后再测试按键。"
         elif not bool(snap.get("mapping_enabled")):
             hint = "提示：映射未启用，请勾选“启用映射”或按启用热键（默认 F8）。"
         elif str(snap.get("mode")) != "battle":
-            hint = "提示：当前为自由鼠标模式（不会触发开火/开镜/自定义点击），请开启“视角锁定”（默认 CapsLock）。"
+            hint = "提示：当前为自由鼠标模式（WASD 摇杆/开火/开镜/自定义点击都不会生效），请开启“视角锁定”（默认 Tab）。"
 
         txt = (
-            "状态：运行中\n"
-            f"配置档：{snap.get('profile')}\n"
-            f"模式：{mode_cn}\n"
-            f"启用映射：{yn(snap.get('mapping_enabled'))} | 视角锁定：{yn(snap.get('camera_lock'))} | 背包打开：{yn(snap.get('backpack_open'))}\n"
+            f"状态：运行中 | 模式：{mode_cn} | 映射：{yn(snap.get('mapping_enabled'))} | 视角锁定：{yn(snap.get('camera_lock'))} | 背包：{yn(snap.get('backpack_open'))}\n"
+            f"WASD检测(上左下右)：ET={et_bits} | 轮询={pol_bits} | 轮询可用：{poll_ok} | 安全输入：{secure_txt} | 最近键盘事件：{age_txt}\n"
             f"{hint}"
         )
         self._lbl_status.setStringValue_(txt)


### PR DESCRIPTION
关联：#33\n\n## 视角：更丝滑 + 修复触边反向拖动\n- 实测 iPhone Mirroring/游戏端对"仅设置 delta 字段"的 drag 不稳定（视角不转）。因此视角改回"绝对坐标拖动"：维护一个触点位置并随鼠标 delta 1:1 移动\n- 触边后自动：drag 到边界 -> mouseUp -> 回锚点（teleport，delta=0）-> mouseDown -> 继续消费剩余位移\n  - 回锚点用 Injector.move_cursor 且 delta=0，避免被记录为反向拖动\n\n## Injector\n- 保留 left_drag_delta（后续若有端支持纯 delta，可再切回）\n- move_cursor 强制 delta=0\n\n## 自测\n- 已在项目虚拟环境中运行：python -m compileall、python -m mirroring_keymap.cli --dry-run\n- 已重新打包：dist/MirroringKeymap.app\n